### PR TITLE
Add Deepgram Nova 3 as a new STT backend

### DIFF
--- a/mazinger/cli/_dub.py
+++ b/mazinger/cli/_dub.py
@@ -78,6 +78,7 @@ def handler(args: argparse.Namespace) -> None:
         tts_language=args.tts_language,
         tts_engine=args.tts_engine,
         mlx_model=args.mlx_tts_model,
+        deepgram_api_key=getattr(args, "deepgram_api_key", None),
         source_language=args.source_language,
         target_language=args.target_language,
         chatterbox_model=args.chatterbox_model,

--- a/mazinger/cli/_groups.py
+++ b/mazinger/cli/_groups.py
@@ -119,6 +119,7 @@ def ensure_transcription(proj, args: argparse.Namespace) -> None:
         device=getattr(args, "device", "cuda"),
         openai_api_key=getattr(args, "openai_api_key", None),
         openai_base_url=getattr(args, "openai_base_url", None),
+        deepgram_api_key=getattr(args, "deepgram_api_key", None),
     )
 
 
@@ -149,6 +150,10 @@ def add_common(p: argparse.ArgumentParser) -> None:
 def add_openai(p: argparse.ArgumentParser) -> None:
     p.add_argument("--openai-api-key", default=os.environ.get("OPENAI_API_KEY"), help="OpenAI API key.")
     p.add_argument("--openai-base-url", default=os.environ.get("OPENAI_BASE_URL"), help="Base URL for OpenAI-compatible API.")
+
+
+def add_deepgram(p: argparse.ArgumentParser) -> None:
+    p.add_argument("--deepgram-api-key", default=os.environ.get("DEEPGRAM_API_KEY"), help="Deepgram API key.")
 
 
 def add_llm(p: argparse.ArgumentParser) -> None:
@@ -221,10 +226,12 @@ def add_segment_mode(p: argparse.ArgumentParser) -> None:
 
 def add_transcription(p: argparse.ArgumentParser) -> None:
     p.add_argument(
-        "--transcribe-method", default="faster-whisper", choices=["openai", "faster-whisper", "whisperx", "mlx-whisper"],
-        help="Transcription backend: 'faster-whisper' (default), 'openai', 'whisperx', or 'mlx-whisper' (Apple Silicon).",
+        "--transcribe-method", default="faster-whisper",
+        choices=["openai", "faster-whisper", "whisperx", "mlx-whisper", "deepgram"],
+        help="Transcription backend: 'faster-whisper' (default), 'openai', 'whisperx', "
+             "'mlx-whisper' (Apple Silicon), or 'deepgram' (cloud).",
     )
-    p.add_argument("--whisper-model", default=None, help="Whisper model name (for openai/faster-whisper/whisperx).")
+    p.add_argument("--whisper-model", default=None, help="Whisper/Deepgram model name.")
     p.add_argument("--mlx-whisper-model", default=DEFAULT_MLX_WHISPER_MODEL,
                    help=f"MLX Whisper model name (default: {DEFAULT_MLX_WHISPER_MODEL}).")
     p.add_argument(
@@ -234,6 +241,7 @@ def add_transcription(p: argparse.ArgumentParser) -> None:
         help="Beam size for decoding when supported by the selected backend (for example, faster-whisper). "
              "Leave unset for mlx-whisper.",
     )
+    add_deepgram(p)
 
 
 def add_cookies(p: argparse.ArgumentParser) -> None:

--- a/mazinger/cli/_transcribe.py
+++ b/mazinger/cli/_transcribe.py
@@ -6,7 +6,7 @@ import argparse
 
 from mazinger.cli._groups import (
     DEFAULT_MLX_WHISPER_MODEL,
-    add_common, add_openai, add_source, resolve_project,
+    add_common, add_deepgram, add_openai, add_source, resolve_project,
 )
 
 
@@ -16,10 +16,12 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     p.add_argument("--audio", default=None, help="Path to audio file (overrides source).")
     p.add_argument("-o", "--output", default=None,
                    help="Output SRT path (default: project transcription/source.srt).")
-    p.add_argument("--method", default="faster-whisper", choices=["openai", "faster-whisper", "whisperx", "mlx-whisper"],
+    p.add_argument("--method", default="faster-whisper",
+                   choices=["openai", "faster-whisper", "whisperx", "mlx-whisper", "deepgram"],
                    help="Transcription backend.")
     p.add_argument("--model", default=None,
-                   help="Model name. Defaults to 'whisper-1' for OpenAI, 'large-v3' for local.")
+                   help="Model name. Defaults to 'whisper-1' for OpenAI, "
+                        "'large-v3' for local, 'nova-3' for Deepgram.")
     p.add_argument("--mlx-whisper-model", default=DEFAULT_MLX_WHISPER_MODEL,
                    help=f"MLX Whisper model name (default: {DEFAULT_MLX_WHISPER_MODEL}).")
     p.add_argument("--device", default="auto", help="Device: auto (default), cuda, or cpu.")
@@ -44,6 +46,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:
                         "(requires --asr-review).")
     p.add_argument("--llm-model", default="gpt-4.1", help="LLM model for refinement.")
     add_openai(p)
+    add_deepgram(p)
     add_common(p)
 
 
@@ -80,6 +83,7 @@ def handler(args: argparse.Namespace) -> None:
         llm_model=args.llm_model,
         openai_api_key=args.openai_api_key,
         openai_base_url=args.openai_base_url,
+        deepgram_api_key=args.deepgram_api_key,
         initial_prompt=args.initial_prompt,
         condition_on_previous_text=not args.no_condition_on_previous_text,
     )

--- a/mazinger/pipeline.py
+++ b/mazinger/pipeline.py
@@ -80,6 +80,7 @@ class MazingerDubber:
         tts_language: str | None = None,
         tts_engine: str = "qwen",
         mlx_model: str = DEFAULT_MLX_MODEL,
+        deepgram_api_key: str | None = None,
         source_language: str = "auto",
         target_language: str = "English",
         chatterbox_model: str = "ResembleAI/chatterbox",
@@ -289,6 +290,7 @@ class MazingerDubber:
                 beam_size=None if transcribe_method == "mlx-whisper" else beam_size,
                 openai_api_key=self._api_key,
                 openai_base_url=self._base_url,
+                deepgram_api_key=deepgram_api_key,
                 skip_resegment=not use_resegmented,
                 initial_prompt=_initial_prompt,
             )

--- a/mazinger/pipeline.py
+++ b/mazinger/pipeline.py
@@ -130,8 +130,11 @@ class MazingerDubber:
                             or filename when ``None``.
             device:         Accelerator device (``cuda`` or ``cpu``).
             transcribe_method: Transcription backend: ``faster-whisper`` (default,
-                            local GPU), ``openai`` (cloud API), or ``whisperx``
-                            (requires [transcribe-whisperx] extra).
+                            local GPU), ``openai`` (cloud API), ``whisperx``
+                            (requires [transcribe-whisperx] extra), or
+                            ``deepgram`` (cloud, requires DEEPGRAM_API_KEY).
+            deepgram_api_key: Deepgram API key (Deepgram method only). Falls
+                            back to ``DEEPGRAM_API_KEY`` environment variable.
             whisper_model:  Whisper model name. Defaults to ``whisper-1`` for OpenAI,
                             ``large-v3`` for faster-whisper/WhisperX.
             tts_model_name: HuggingFace model identifier for TTS.

--- a/mazinger/transcribe.py
+++ b/mazinger/transcribe.py
@@ -1,6 +1,6 @@
-"""Transcribe audio to SRT using OpenAI Whisper API, faster-whisper, WhisperX, or MLX Whisper.
+"""Transcribe audio to SRT using OpenAI Whisper, faster-whisper, WhisperX, MLX Whisper, or Deepgram.
 
-Supports three transcription backends:
+Supports five transcription backends:
 - **openai** (default): Uses OpenAI's Whisper API. No local GPU required,
   simple setup, works with any transformers version. Requires OPENAI_API_KEY.
 - **faster-whisper**: Fast local transcription using CTranslate2. 4x faster
@@ -11,6 +11,9 @@ Supports three transcription backends:
   with chatterbox-tts due to conflicting transformers requirements.
 - **mlx-whisper**: MLX-accelerated Whisper for Apple Silicon. Runs natively
   on M-series GPUs. Requires [transcribe-mlx] extra.
+- **deepgram**: Uses Deepgram's Nova API for fast, accurate cloud
+  transcription with word-level timestamps. Supports 47+ languages.
+  Requires DEEPGRAM_API_KEY. Requires [transcribe-deepgram] extra.
 """
 
 from __future__ import annotations
@@ -24,7 +27,7 @@ from typing import Any, Literal
 log = logging.getLogger(__name__)
 
 # Supported transcription methods
-TranscribeMethod = Literal["openai", "faster-whisper", "whisperx", "mlx-whisper"]
+TranscribeMethod = Literal["openai", "faster-whisper", "whisperx", "mlx-whisper", "deepgram"]
 
 # Module-level cache for faster-whisper models — avoids reloading across runs
 _whisper_cache: dict[str, Any] = {}
@@ -881,6 +884,128 @@ def _transcribe_mlx_whisper(
     return raw_segments, detected_lang
 
 
+# ── Deepgram Nova API backend ───────────────────────────────────────────────
+
+def _transcribe_deepgram(
+    audio_path: str,
+    *,
+    model: str = "nova-3",
+    language: str | None = None,
+    api_key: str | None = None,
+    keyterms: list[str] | None = None,
+) -> tuple[list[dict], str]:
+    """Transcribe using Deepgram's Nova STT API.
+
+    Deepgram Nova-3 is a fast, accurate cloud transcription service
+    supporting 47+ languages with word-level timestamps.
+
+    Requires: pip install "mazinger[transcribe-deepgram]"
+
+    Returns:
+        A tuple of (segments, detected_language).
+        Each segment has 'start', 'end', 'text', and 'words' keys.
+    """
+    try:
+        from deepgram import DeepgramClient
+    except ImportError as e:
+        raise ImportError(
+            "deepgram-sdk not installed. Install with: pip install 'mazinger[transcribe-deepgram]'\n"
+            "Or use method='openai' for cloud-based transcription."
+        ) from e
+
+    client = DeepgramClient(api_key=api_key) if api_key else DeepgramClient()
+
+    file_size = os.path.getsize(audio_path)
+    _WARN_THRESHOLD = 100 * 1024 * 1024  # 100 MiB
+    if file_size > _WARN_THRESHOLD:
+        log.warning(
+            "Audio file is %.0f MiB — reading into memory for Deepgram upload. "
+            "For very large files consider splitting or compressing first.",
+            file_size / (1024 * 1024),
+        )
+
+    with open(audio_path, "rb") as f:
+        buffer_data = f.read()
+
+    options_kw: dict[str, Any] = {
+        "model": model,
+        "smart_format": True,
+        "punctuate": True,
+        "utterances": True,
+    }
+    if language:
+        options_kw["language"] = language
+    else:
+        options_kw["detect_language"] = True
+
+    # Nova-3 keyterm boosting: improve recognition of domain-specific terms
+    # extracted from video metadata (title, tags, description).
+    if keyterms and "nova-3" in model:
+        options_kw["keyterm"] = keyterms[:100]
+
+    log.info("Calling Deepgram API (model=%s)...", model)
+    response = client.listen.v1.media.transcribe_file(
+        request=buffer_data, **options_kw,
+    )
+
+    # Extract detected language and confidence
+    detected_lang = "unknown"
+    channels = response.results.channels
+    if channels:
+        detected_lang = getattr(channels[0], "detected_language", None) or "unknown"
+        lang_confidence = getattr(channels[0], "language_confidence", None)
+        if lang_confidence is not None:
+            log.info("Detected language: %s (confidence: %.2f)", detected_lang, lang_confidence)
+        else:
+            log.info("Detected language: %s", detected_lang)
+
+    # Build segments from utterances (natural speech boundaries)
+    raw_segments: list[dict] = []
+    utterances = getattr(response.results, "utterances", None)
+    if utterances:
+        for utt in utterances:
+            segment: dict[str, Any] = {
+                "start": utt.start,
+                "end": utt.end,
+                "text": utt.transcript.strip(),
+            }
+            if utt.words:
+                segment["words"] = [
+                    {
+                        "word": getattr(w, "punctuated_word", None) or w.word,
+                        "start": w.start,
+                        "end": w.end,
+                    }
+                    for w in utt.words
+                ]
+            raw_segments.append(segment)
+    elif channels:
+        # Fallback: build a single segment from the full transcript
+        alt = channels[0].alternatives[0]
+        if alt.transcript.strip():
+            segment = {
+                "start": alt.words[0].start if alt.words else 0.0,
+                "end": alt.words[-1].end if alt.words else 0.0,
+                "text": alt.transcript.strip(),
+            }
+            if alt.words:
+                segment["words"] = [
+                    {
+                        "word": getattr(w, "punctuated_word", None) or w.word,
+                        "start": w.start,
+                        "end": w.end,
+                    }
+                    for w in alt.words
+                ]
+            raw_segments.append(segment)
+
+    log.info(
+        "Deepgram transcription complete: %d segments, language=%s",
+        len(raw_segments), detected_lang,
+    )
+    return raw_segments, detected_lang
+
+
 # ── LLM-based text refinement ────────────────────────────────────────────────
 
 def _refine_segments_llm(
@@ -967,6 +1092,7 @@ def transcribe(
     llm_model: str = "gpt-4.1",
     openai_api_key: str | None = None,
     openai_base_url: str | None = None,
+    deepgram_api_key: str | None = None,
     initial_prompt: str | None = None,
     condition_on_previous_text: bool = True,
     vad_options: dict | None = None,
@@ -1066,8 +1192,26 @@ def transcribe(
             vad_options=vad_options,
             word_timestamps=word_timestamps,
         )
+    elif method == "deepgram":
+        default_model = "nova-3"
+        # Extract keyterms from initial_prompt for Nova-3 term boosting
+        keyterms = None
+        if initial_prompt:
+            keyterms = [
+                t.strip() for t in re.split(r"[.,;|]+", initial_prompt) if t.strip()
+            ]
+        raw_segments, detected_lang = _transcribe_deepgram(
+            audio_path,
+            model=model or default_model,
+            language=language,
+            api_key=deepgram_api_key,
+            keyterms=keyterms,
+        )
     else:
-        raise ValueError(f"Unknown transcription method: {method!r}. Use 'openai', 'faster-whisper', 'whisperx', or 'mlx-whisper'.")
+        raise ValueError(
+            f"Unknown transcription method: {method!r}. "
+            "Use 'openai', 'faster-whisper', 'whisperx', 'mlx-whisper', or 'deepgram'."
+        )
 
     log.info("Transcription complete: %d segments, language=%s", len(raw_segments), detected_lang)
 

--- a/mazinger/transcribe.py
+++ b/mazinger/transcribe.py
@@ -1098,15 +1098,17 @@ def transcribe(
     vad_options: dict | None = None,
     word_timestamps: bool = True,
 ) -> str:
-    """Transcribe audio to SRT using OpenAI Whisper API, faster-whisper, WhisperX, or MLX Whisper.
+    """Transcribe audio to SRT using OpenAI Whisper, faster-whisper, WhisperX, MLX Whisper, or Deepgram.
 
     Parameters:
         audio_path:     Path to the input audio file.
         output_path:    Where to save the final SRT.
         method:         Transcription backend: ``faster-whisper`` (default),
-                        ``openai``, ``whisperx``, or ``mlx-whisper``.
+                        ``openai``, ``whisperx``, ``mlx-whisper``, or
+                        ``deepgram``.
         model:          Model name. Defaults to ``whisper-1`` for OpenAI,
-                        ``large-v3`` for faster-whisper and WhisperX.
+                        ``large-v3`` for faster-whisper/WhisperX,
+                        ``nova-3`` for Deepgram.
         device:         ``cuda`` or ``cpu`` (local methods only).
         batch_size:     Inference batch size (local methods only).
         compute_type:   ``float16``, ``int8``, or ``int8_float16`` (local methods).
@@ -1117,6 +1119,8 @@ def transcribe(
         skip_resegment: When ``True``, keep original segments as-is.
         openai_api_key: OpenAI API key (OpenAI method only). Falls back to
                         ``OPENAI_API_KEY`` environment variable.
+        deepgram_api_key: Deepgram API key (Deepgram method only). Falls back
+                        to ``DEEPGRAM_API_KEY`` environment variable.
 
     Returns:
         The path to the saved SRT file.
@@ -1133,6 +1137,9 @@ def transcribe(
 
         # Using WhisperX (requires [transcribe-whisperx] extra)
         transcribe("audio.mp3", "output.srt", method="whisperx", device="cuda")
+
+        # Using Deepgram Nova-3 (cloud, fast and accurate)
+        transcribe("audio.mp3", "output.srt", method="deepgram")
 
         # Using MLX Whisper (Apple Silicon, requires [transcribe-mlx] extra)
         transcribe("audio.mp3", "output.srt", method="mlx-whisper")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,11 @@ transcribe-whisperx = [
     "scipy>=1.14",          # ABI-compatible with numpy 2.x (Colab Fix)
     "scikit-learn>=1.5",    # Pulled by transformers; must match scipy
 ]
+# Cloud transcription with Deepgram Nova API
+# Compatible with ALL TTS engines (no local GPU or transformers dependency).
+transcribe-deepgram = [
+    "deepgram-sdk>=6.0",
+]
 # Alias for convenience (points to faster-whisper)
 transcribe = [
     "mazinger[transcribe-faster]",


### PR DESCRIPTION
## Summary
- Adds **Deepgram Nova 3** as a fourth transcription backend (`--method deepgram`) alongside OpenAI Whisper, faster-whisper, and WhisperX
- Cloud-based, no local GPU required, supports 47+ languages with word-level timestamps
- Leverages Nova-3's `keyterm` boosting using video metadata (title, tags, description) for improved recognition of domain-specific terms
- New optional dependency: `pip install "mazinger[transcribe-deepgram]"`

## Changes
| File | Change |
|---|---|
| `transcribe.py` | New `_transcribe_deepgram()` backend, updated `TranscribeMethod`, dispatch case, `deepgram_api_key` param |
| `cli/_transcribe.py` | Added `"deepgram"` to `--method` choices, `--deepgram-api-key` arg |
| `cli/_groups.py` | New `add_deepgram()` helper, `"deepgram"` in `add_transcription()`, pass-through in `ensure_transcription()` |
| `cli/_dub.py` | Pass `deepgram_api_key` to `dubber.dub()` |
| `pipeline.py` | `deepgram_api_key` param on `dub()`, pass-through to `transcribe()` |
| `pyproject.toml` | New `transcribe-deepgram` optional extra (`deepgram-sdk>=6.0`) |

## Usage
```bash
# Standalone transcription
export DEEPGRAM_API_KEY=your_key
mazinger transcribe video.mp4 --method deepgram

# Full dubbing pipeline
mazinger dub video.mp4 --transcribe-method deepgram --deepgram-api-key YOUR_KEY
```

## Test plan
- [x] Verified all imports work with deepgram-sdk v6.1.1
- [x] Tested end-to-end on Arabic audio — 18 subtitle segments with correct word-level timestamps
- [x] Verified CLI parser builds without conflicts (`transcribe` and `dub` commands)
- [x] Verified resegmentation works correctly with Deepgram's utterance + word timestamps
- [ ] Test with `--language` auto-detection (omit `--language` flag)
- [ ] Test via full `dub` pipeline end-to-end