### PR TITLE
Fix clip_timestamps format, Windows UTF-8 console, and non-dict LLM response

### DIFF
--- a/mazinger/cli/__init__.py
+++ b/mazinger/cli/__init__.py
@@ -62,6 +62,15 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> None:
+    # Windows console defaults to cp1252 which cannot encode Arabic/CJK/etc.
+    # Reconfigure stdout/stderr to UTF-8 so project names and log messages
+    # with non-Latin characters don't crash with UnicodeEncodeError.
+    import sys
+    if sys.platform == "win32":
+        for stream in (sys.stdout, sys.stderr):
+            if hasattr(stream, "reconfigure"):
+                stream.reconfigure(encoding="utf-8", errors="replace")
+
     parser = _build_parser()
     args = parser.parse_args(argv)
     _configure_logging(getattr(args, "verbose", False))

--- a/mazinger/describe.py
+++ b/mazinger/describe.py
@@ -151,6 +151,12 @@ def describe_content(
         usage_tracker.record("describe", llm_model, resp)
     description = json_repair.loads(resp.choices[0].message.content)
 
+    # Guard: small/local LLMs may return a non-dict (list, string, etc.).
+    # Wrap into the expected schema so downstream code doesn't crash.
+    if not isinstance(description, dict):
+        log.warning("LLM returned non-dict description (%s), wrapping into schema", type(description).__name__)
+        description = {"title": "", "summary": str(description), "keypoints": [], "keywords": []}
+
     # ── Post-process: deduplicate keypoints and keywords ──────────
     if isinstance(description.get("keypoints"), list):
         seen = set()

--- a/mazinger/transcribe.py
+++ b/mazinger/transcribe.py
@@ -569,12 +569,14 @@ def _transcribe_faster_whisper(
         log.info("VAD detected no speech — transcribing full audio")
         speech_clips = [{"start": 0, "end": audio_samples}]
 
-    # Convert from sample indices to seconds (the batched pipeline
-    # expects seconds when clip_timestamps is provided externally).
-    speech_clips_sec = [
-        {"start": c["start"] / sampling_rate, "end": c["end"] / sampling_rate}
-        for c in speech_clips
-    ]
+    # Convert from sample indices to a flat list of seconds:
+    #   [start1, end1, start2, end2, ...]
+    # BatchedInferencePipeline.transcribe() expects clip_timestamps
+    # as a flat sequence of boundary pairs in seconds.
+    speech_clips_sec: list[float] = []
+    for c in speech_clips:
+        speech_clips_sec.append(c["start"] / sampling_rate)
+        speech_clips_sec.append(c["end"] / sampling_rate)
 
     # Use batched inference for better performance
     batched_model = BatchedInferencePipeline(model=whisper_model)


### PR DESCRIPTION
## Summary
Three bug fixes discovered during end-to-end testing of the pipeline:

### 1. `clip_timestamps` format bug (faster-whisper backend)
`_transcribe_faster_whisper()` passes `speech_clips_sec` as a **list of dicts** (`[{"start": 0.5, "end": 3.2}, ...]`) to `clip_timestamps`, but `BatchedInferencePipeline.transcribe()` expects a **flat list of seconds** (`[0.5, 3.2, ...]`). This causes a `TypeError` at runtime.

**Fix:** Convert to flat `[start1, end1, start2, end2, ...]` format.

### 2. Windows console UnicodeEncodeError
On Windows, `sys.stdout` defaults to `cp1252` encoding, which cannot represent Arabic, CJK, or other non-Latin characters. Any `print()` or log message containing a non-Latin project slug (e.g. `مين-هو-مستر-عزت`) crashes with `UnicodeEncodeError`.

**Fix:** Reconfigure `stdout`/`stderr` to UTF-8 with `errors="replace"` at CLI entry point, guarded by `sys.platform == "win32"`.

### 3. `describe.py` crash on non-dict LLM response
`json_repair.loads()` can return a list, string, or `None` when small/local LLMs (e.g. Ollama `qwen3:4b`) produce malformed JSON. The subsequent `.get()` call crashes with `AttributeError: 'list' object has no attribute 'get'`.

**Fix:** Guard with `isinstance(description, dict)` check, wrapping non-dict responses into the expected schema.

## Test plan
- [x] Verified all modified modules import correctly
- [ ] Test faster-whisper transcription with `--method faster-whisper` (requires GPU or CPU with the model)
- [ ] Test pipeline with non-Latin project names on Windows
- [ ] Test `describe` stage with a small local LLM (e.g. Ollama qwen3:4b)