### PR TITLE
Add Google Gemini as an LLM provider

### DIFF
--- a/mazinger/cli/_dub.py
+++ b/mazinger/cli/_dub.py
@@ -62,6 +62,7 @@ def handler(args: argparse.Namespace) -> None:
         llm_model=args.llm_model,
         base_dir=args.base_dir,
         llm_think=args.llm_think,
+        gemini_api_key=getattr(args, "gemini_api_key", None),
     )
     proj = dubber.dub(
         source=args.source,

--- a/mazinger/cli/_groups.py
+++ b/mazinger/cli/_groups.py
@@ -151,8 +151,13 @@ def add_openai(p: argparse.ArgumentParser) -> None:
     p.add_argument("--openai-base-url", default=os.environ.get("OPENAI_BASE_URL"), help="Base URL for OpenAI-compatible API.")
 
 
+def add_gemini(p: argparse.ArgumentParser) -> None:
+    p.add_argument("--gemini-api-key", default=os.environ.get("GEMINI_API_KEY"), help="Google Gemini API key.")
+
+
 def add_llm(p: argparse.ArgumentParser) -> None:
     add_openai(p)
+    add_gemini(p)
     p.add_argument("--llm-model", default=os.environ.get("OPENAI_MODEL", "gpt-4.1"), help="LLM model for translation/analysis.")
     p.add_argument(
         "--llm-think", action=argparse.BooleanOptionalAction, default=None,
@@ -302,6 +307,7 @@ def make_llm_client(args: argparse.Namespace):
         api_key=getattr(args, "openai_api_key", None),
         base_url=getattr(args, "openai_base_url", None),
         think=getattr(args, "llm_think", None),
+        gemini_api_key=getattr(args, "gemini_api_key", None),
     )
 
 

--- a/mazinger/cli/_transcribe.py
+++ b/mazinger/cli/_transcribe.py
@@ -6,7 +6,7 @@ import argparse
 
 from mazinger.cli._groups import (
     DEFAULT_MLX_WHISPER_MODEL,
-    add_common, add_openai, add_source, resolve_project,
+    add_common, add_gemini, add_openai, add_source, resolve_project,
 )
 
 
@@ -44,6 +44,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:
                         "(requires --asr-review).")
     p.add_argument("--llm-model", default="gpt-4.1", help="LLM model for refinement.")
     add_openai(p)
+    add_gemini(p)
     add_common(p)
 
 
@@ -96,6 +97,7 @@ def handler(args: argparse.Namespace) -> None:
         client = build_client(
             api_key=args.openai_api_key,
             base_url=args.openai_base_url,
+            gemini_api_key=getattr(args, "gemini_api_key", None),
         )
 
         description = describe_content(

--- a/mazinger/llm.py
+++ b/mazinger/llm.py
@@ -1,8 +1,9 @@
-"""LLM client factory with native Ollama support.
+"""LLM client factory with native Ollama and Gemini support.
 
 When the base URL points to an Ollama server, requests are routed through
 the native ``/api/chat`` endpoint so that parameters like ``think`` are
-handled correctly.  For all other providers the standard OpenAI SDK is used.
+handled correctly.  When a Gemini API key is provided, the Google GenAI
+SDK is used.  For all other providers the standard OpenAI SDK is used.
 
 Streaming
 ---------
@@ -255,6 +256,169 @@ class _OllamaClient:
             log.debug("Ollama unload request failed (non-critical)", exc_info=True)
 
 
+# -- Gemini (Google GenAI) native chat ------------------------------------
+
+class _GeminiChatCompletions:
+    """Translate OpenAI-style ``create()`` calls to Google GenAI SDK."""
+
+    _UNSUPPORTED_KEYS = frozenset({
+        "repeat_penalty", "top_k", "num_predict", "think",
+        "compression_ratio_threshold", "log_prob_threshold",
+        "no_speech_threshold",
+    })
+
+    def __init__(self, api_key: str) -> None:
+        try:
+            from google import genai
+        except ImportError as e:
+            raise ImportError(
+                "google-genai not installed. Install with: "
+                "pip install 'mazinger[llm-gemini]'\n"
+                "Or use an OpenAI-compatible provider."
+            ) from e
+        self._client = genai.Client(api_key=api_key)
+
+    @staticmethod
+    def _convert_messages(
+        messages: list[dict[str, Any]],
+    ) -> tuple[str | None, list[dict[str, Any]]]:
+        """Split OpenAI messages into Gemini system_instruction + contents."""
+        import base64
+        from google.genai import types
+
+        system_text: list[str] = []
+        contents: list[dict[str, Any]] = []
+
+        for msg in messages:
+            role = msg["role"]
+            raw_content = msg.get("content", "")
+
+            if role == "system":
+                if isinstance(raw_content, str):
+                    system_text.append(raw_content)
+                elif isinstance(raw_content, list):
+                    system_text.extend(
+                        p["text"] for p in raw_content if p.get("type") == "text"
+                    )
+                continue
+
+            gemini_role = "model" if role == "assistant" else "user"
+            parts: list[types.Part] = []
+
+            if isinstance(raw_content, str):
+                parts.append(types.Part.from_text(text=raw_content))
+            elif isinstance(raw_content, list):
+                for block in raw_content:
+                    if block.get("type") == "text":
+                        parts.append(types.Part.from_text(text=block["text"]))
+                    elif block.get("type") == "image_url":
+                        url = block.get("image_url", {}).get("url", "")
+                        if url.startswith("data:"):
+                            header, b64_data = url.split(",", 1)
+                            mime = header.split(":")[1].split(";")[0]
+                            parts.append(types.Part.from_bytes(
+                                data=base64.b64decode(b64_data),
+                                mime_type=mime,
+                            ))
+
+            if parts:
+                contents.append(types.Content(role=gemini_role, parts=parts))
+
+        system_instruction = "\n".join(system_text) if system_text else None
+        return system_instruction, contents
+
+    def create(
+        self,
+        *,
+        model: str,
+        messages: list[dict[str, Any]],
+        temperature: float = 1.0,
+        **kwargs: Any,
+    ) -> _ChatCompletion:
+        from google.genai import types
+
+        system_instruction, contents = self._convert_messages(messages)
+
+        config_kw: dict[str, Any] = {"temperature": temperature}
+        if system_instruction:
+            config_kw["system_instruction"] = system_instruction
+        if "top_p" in kwargs:
+            config_kw["top_p"] = kwargs["top_p"]
+        if "seed" in kwargs:
+            config_kw["seed"] = kwargs["seed"]
+        max_tokens = kwargs.get("max_tokens") or kwargs.get("num_predict")
+        if max_tokens:
+            config_kw["max_output_tokens"] = max_tokens
+        if "frequency_penalty" in kwargs:
+            config_kw["frequency_penalty"] = kwargs["frequency_penalty"]
+        if "presence_penalty" in kwargs:
+            config_kw["presence_penalty"] = kwargs["presence_penalty"]
+
+        callback = get_stream_callback()
+
+        def _call(kw: dict[str, Any]) -> _ChatCompletion:
+            config = types.GenerateContentConfig(**kw)
+
+            if not callback:
+                response = self._client.models.generate_content(
+                    model=model, contents=contents, config=config,
+                )
+                text = response.text or ""
+                usage = response.usage_metadata
+                p_tok = getattr(usage, "prompt_token_count", 0) or 0
+                c_tok = getattr(usage, "response_token_count", 0) or 0
+            else:
+                parts: list[str] = []
+                p_tok = c_tok = 0
+                for chunk in self._client.models.generate_content_stream(
+                    model=model, contents=contents, config=config,
+                ):
+                    token = chunk.text or ""
+                    if token:
+                        parts.append(token)
+                        try:
+                            callback(token)
+                        except Exception:
+                            pass
+                    usage = chunk.usage_metadata
+                    if usage:
+                        p_tok = getattr(usage, "prompt_token_count", 0) or 0
+                        c_tok = getattr(usage, "response_token_count", 0) or 0
+                text = "".join(parts)
+
+            return _ChatCompletion(
+                choices=[_Choice(_Message("assistant", text))],
+                usage=_Usage(p_tok, c_tok),
+            )
+
+        try:
+            return _call(config_kw)
+        except Exception as exc:
+            err_msg = str(exc).lower()
+            if "penalty" in err_msg and (
+                "frequency_penalty" in config_kw or "presence_penalty" in config_kw
+            ):
+                log.debug("Gemini rejected penalty params, retrying without them")
+                config_kw.pop("frequency_penalty", None)
+                config_kw.pop("presence_penalty", None)
+                return _call(config_kw)
+            raise
+
+
+class _GeminiChat:
+    __slots__ = ("completions",)
+
+    def __init__(self, completions: _GeminiChatCompletions) -> None:
+        self.completions = completions
+
+
+class _GeminiClient:
+    """Drop-in replacement for ``openai.OpenAI`` that talks to Google Gemini."""
+
+    def __init__(self, api_key: str) -> None:
+        self.chat = _GeminiChat(_GeminiChatCompletions(api_key))
+
+
 # -- Factory ---------------------------------------------------------------
 
 
@@ -344,13 +508,20 @@ def build_client(
     api_key: str | None = None,
     base_url: str | None = None,
     think: bool | None = None,
+    gemini_api_key: str | None = None,
 ) -> Any:
     """Return an LLM client appropriate for the given backend.
 
     For Ollama endpoints, returns a lightweight native client that honours
-    the ``think`` parameter.  For everything else, returns a standard
-    ``openai.OpenAI`` instance (wrapped for stream-callback support).
+    the ``think`` parameter.  When *gemini_api_key* is provided, returns a
+    Gemini client using the Google GenAI SDK.  For everything else, returns
+    a standard ``openai.OpenAI`` instance (wrapped for stream-callback
+    support).
     """
+    if gemini_api_key:
+        log.debug("Using Gemini client (google-genai)")
+        return _GeminiClient(gemini_api_key)
+
     if _is_ollama_url(base_url):
         ollama_base = _ollama_base(base_url)
         log.debug("Using native Ollama client → %s", ollama_base)

--- a/mazinger/pipeline.py
+++ b/mazinger/pipeline.py
@@ -38,12 +38,14 @@ class MazingerDubber:
         llm_model: str | None = None,
         base_dir: str = "./mazinger_output",
         llm_think: bool | None = None,
+        gemini_api_key: str | None = None,
     ) -> None:
         self.llm_model = llm_model or os.environ.get("OPENAI_MODEL") or "gpt-4.1"
         self.base_dir = base_dir
         self._api_key = openai_api_key or os.environ.get("OPENAI_API_KEY")
         self._base_url = openai_base_url or os.environ.get("OPENAI_BASE_URL")
         self._llm_think = llm_think
+        self._gemini_api_key = gemini_api_key or os.environ.get("GEMINI_API_KEY")
 
     # ------------------------------------------------------------------
     #  Internal helpers
@@ -56,6 +58,7 @@ class MazingerDubber:
             api_key=self._api_key,
             base_url=self._base_url,
             think=self._llm_think,
+            gemini_api_key=self._gemini_api_key,
         )
 
     # ------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,10 @@ transcribe-whisperx = [
     "scipy>=1.14",          # ABI-compatible with numpy 2.x (Colab Fix)
     "scikit-learn>=1.5",    # Pulled by transformers; must match scipy
 ]
+# Google Gemini LLM provider (alternative to OpenAI for translation/analysis)
+llm-gemini = [
+    "google-genai>=1.0",
+]
 # Alias for convenience (points to faster-whisper)
 transcribe = [
     "mazinger[transcribe-faster]",


### PR DESCRIPTION
## Summary
- Adds **Google Gemini** as a third LLM provider alongside OpenAI and Ollama
- Implements `_GeminiClient` that mimics the `client.chat.completions.create()` interface, so all existing pipeline stages (describe, review, translate, resegment, thumbnails) work without changes
- Supports text, multimodal (base64 images), and streaming via `generate_content_stream`
- Converts OpenAI message format to Gemini's `Content`/`Part` types (including `system` → `system_instruction`)
- New optional dependency: `pip install "mazinger[llm-gemini]"`

## Changes
| File | Change |
|---|---|
| `llm.py` | New `_GeminiChatCompletions`, `_GeminiChat`, `_GeminiClient` classes; `gemini_api_key` param on `build_client()` |
| `cli/_groups.py` | New `add_gemini()` helper, wired into `add_llm()` and `make_llm_client()` |
| `cli/_dub.py` | Pass `gemini_api_key` to `MazingerDubber` |
| `cli/_transcribe.py` | Pass `gemini_api_key` to `build_client()` for ASR review |
| `pipeline.py` | `gemini_api_key` on `__init__` and `_llm_client()` |
| `pyproject.toml` | New `llm-gemini` optional extra (`google-genai>=1.0`) |

## Usage
```bash
# Set API key
export GEMINI_API_KEY=your_key

# Full dubbing pipeline with Gemini for all LLM stages
mazinger dub video.mp4 --llm-model gemini-2.5-flash

# Or pass key explicitly
mazinger dub video.mp4 --gemini-api-key KEY --llm-model gemini-2.5-flash
```

## Test plan
- [x] Verified text completion with `gemini-2.5-flash` — correct response and usage metrics
- [x] Verified multimodal (image) completion — correctly identifies image content
- [x] Verified CLI parser builds without conflicts across all subcommands
- [x] Verified `MazingerDubber` accepts and passes `gemini_api_key` through to `build_client()`
- [ ] Test full `dub` pipeline end-to-end with Gemini as LLM provider