### PR TITLE
Add Pocket TTS as a lightweight CPU-only TTS engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Mazinger chains ten stages into a single pipeline:
 5. **Review** — optionally refine ASR output: fix typos, reshape punctuation, and convert technical terms to English
 6. **Translate** — translate the SRT into another language with duration-aware word budgets
 7. **Re-segment** — merge fragments and split oversized subtitles for readability
-8. **Speak** — synthesize voice-cloned speech for every subtitle entry (Qwen3-TTS, Chatterbox, or MLX), with 16 pre-defined voice themes or your own voice sample
+8. **Speak** — synthesize voice-cloned speech for every subtitle entry (Qwen3-TTS, Chatterbox, MLX, or Pocket TTS), with 16 pre-defined voice themes or your own voice sample
 9. **Assemble** — place each audio segment on the original timeline with optional tempo adjustment, loudness matching, and background audio mixing
 10. **Subtitle** — burn styled subtitles into the video and/or mux the new audio track
 
@@ -59,6 +59,7 @@ pip install "mazinger[transcribe-whisperx]"    # WhisperX (optional, word-level 
 pip install "mazinger[tts]"                    # Qwen3-TTS (voice sample + transcript)
 pip install "mazinger[tts-chatterbox]"         # Chatterbox (voice sample only, emotion control)
 pip install "mazinger[tts-mlx]"                # MLX Qwen3-TTS (Apple Silicon)
+pip install "mazinger[tts-pocket]"             # Pocket TTS (Kyutai, CPU-only, English only)
 
 # MLX transcription (Apple Silicon)
 pip install "mazinger[transcribe-mlx]"         # MLX Whisper (Apple Silicon)
@@ -140,6 +141,32 @@ mazinger dub "https://youtube.com/watch?v=VIDEO_ID" \
     --subtitle-google-font "Noto Sans Arabic" \
     --subtitle-font-size 24
 ```
+
+### Dub without a GPU (Pocket TTS, CPU-only)
+
+[Pocket TTS](https://github.com/kyutai-labs/pocket-tts) (Kyutai, 100M params) runs entirely
+on CPU with no GPU required — ideal for low-resource machines, CI servers, or quick
+drafts. It ships with 8 predefined voices (no files or HF account needed) and also
+supports zero-shot voice cloning from a short reference clip. **English only**.
+
+```bash
+pip install "mazinger[tts-pocket]"
+
+# With a predefined voice — no voice sample needed
+mazinger dub "https://youtube.com/watch?v=VIDEO_ID" \
+    --tts-engine pocket --pocket-voice alba \
+    --target-language English
+
+# With voice cloning from your own audio (requires HF gated access +
+# `hf auth login` — see https://huggingface.co/kyutai/pocket-tts)
+mazinger dub "https://youtube.com/watch?v=VIDEO_ID" \
+    --tts-engine pocket \
+    --voice-sample speaker.wav \
+    --target-language English
+```
+
+Predefined voices: `alba` · `marius` · `javert` · `jean` · `fantine` · `cosette` · `eponine` · `azelma`.
+Long reference clips are automatically trimmed to 30 s to prevent hallucination.
 
 ### Run a single stage
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -50,13 +50,14 @@ mazinger dub <source> [options]
 | `--asr-review` | off | Review ASR transcript with LLM to fix typos and punctuation |
 | `--keep-technical-english` | off | Convert technical terms to English in the source transcript (requires `--asr-review`) |
 | `--youtube-subs` | off | Download YouTube subtitles and compare with ASR to pick the best source |
-| `--tts-engine` | `qwen` | `qwen`, `chatterbox`, or `mlx` |
+| `--tts-engine` | `qwen` | `qwen`, `chatterbox`, `mlx`, or `pocket` (CPU-only, English only) |
 | `--tts-model` | `Qwen/Qwen3-TTS-12Hz-1.7B-Base` | Qwen model ID |
 | `--mlx-tts-model` | `mlx-community/Qwen3-TTS-12Hz-0.6B-Base-bf16` | MLX TTS model name |
 | `--chatterbox-model` | `ResembleAI/chatterbox` | Chatterbox model ID |
 | `--tts-language` | same as `--target-language` | Language hint for TTS |
 | `--chatterbox-exaggeration` | `0.5` | Emotion intensity (0.0–1.0) |
 | `--chatterbox-cfg` | `0.5` | Pacing control (0.0–1.0) |
+| `--pocket-voice` | — | Predefined Pocket TTS voice (`alba`, `marius`, `javert`, `jean`, `fantine`, `cosette`, `eponine`, `azelma`). Overrides `--voice-sample` when `--tts-engine pocket`. |
 | `--use-resegmented` | off | Use resegmented SRT instead of raw transcription |
 | `--output-type` | `audio` | `audio` (WAV only) or `video` (muxed MP4) |
 | `--embed-subtitles` | off | Burn subtitles into output video (implies `--output-type video`) |
@@ -363,13 +364,14 @@ mazinger speak [source] [options]
 | `--voice-script` | — | Path to transcript of voice sample |
 | `-o`, `--output` | — | Output WAV path |
 | `--segments-dir` | — | Directory for individual segment WAVs |
-| `--tts-engine` | `qwen` | `qwen`, `chatterbox`, or `mlx` |
+| `--tts-engine` | `qwen` | `qwen`, `chatterbox`, `mlx`, or `pocket` (CPU-only, English only) |
 | `--tts-model` | `Qwen/Qwen3-TTS-12Hz-1.7B-Base` | Qwen model ID |
 | `--mlx-tts-model` | `mlx-community/Qwen3-TTS-12Hz-0.6B-Base-bf16` | MLX TTS model name |
 | `--chatterbox-model` | `ResembleAI/chatterbox` | Chatterbox model ID |
 | `--tts-language` | — | Language hint for TTS |
 | `--chatterbox-exaggeration` | `0.5` | Emotion intensity (0.0–1.0) |
 | `--chatterbox-cfg` | `0.5` | Pacing control (0.0–1.0) |
+| `--pocket-voice` | — | Predefined Pocket TTS voice (`alba`, `marius`, etc.) — overrides `--voice-sample` for `--tts-engine pocket` |
 | `--device` | `auto` | `auto`, `cuda`, `cpu` |
 | `--dtype` | `bfloat16` | Weight dtype for Qwen: `bfloat16`, `float16`, `float32` |
 | `--dynamic-tempo` | off | Per-segment tempo matching |
@@ -394,6 +396,10 @@ mazinger speak --srt translated.srt --original-audio audio.mp3 \
     --tts-engine chatterbox \
     --chatterbox-exaggeration 0.7 --chatterbox-cfg 0.3 \
     -o dubbed.wav
+
+# Pocket TTS (CPU-only, predefined voice, no files needed)
+mazinger speak --srt translated.srt --original-audio audio.mp3 \
+    --tts-engine pocket --pocket-voice alba -o dubbed.wav
 
 # Fixed tempo speed-up
 mazinger speak --srt translated.srt --original-audio audio.mp3 \

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,11 @@ Both require a CUDA GPU (or can fall back to CPU at reduced speed).
 pip install "mazinger[tts]"                    # Qwen3-TTS — needs a voice sample + transcript
 pip install "mazinger[tts-chatterbox]"         # Chatterbox — needs only a voice sample, has emotion control
 pip install "mazinger[tts-mlx]"                # MLX Qwen3-TTS — Apple Silicon (M1/M2/M3/M4/M5)
+pip install "mazinger[tts-pocket]"             # Pocket TTS — CPU-only, English only, 8 predefined voices
 ```
+
+Pocket TTS is the only TTS backend that runs without a GPU. It's useful for CI,
+low-resource machines, or when you just want to prototype without configuring CUDA.
 
 ### MLX Transcription (Apple Silicon)
 
@@ -52,6 +56,7 @@ Qwen, Chatterbox, and MLX pull different versions of `transformers` and cannot c
 | `tts` (Qwen) | ≥ 4.48 | `transcribe-faster`, `transcribe-whisperx` |
 | `tts-chatterbox` | == 4.46.3 | `transcribe-faster`, OpenAI transcription |
 | `tts-mlx` | (mlx-audio) | `transcribe-mlx` |
+| `tts-pocket` | (not required) | any transcription backend (no GPU, CPU-only) |
 | `all-mlx` | (mlx-audio + mlx-whisper) | Apple Silicon only |
 
 WhisperX requires `transformers>=4.48`, so it conflicts with Chatterbox. When using Chatterbox, choose `transcribe-faster` or the cloud-based OpenAI transcription.
@@ -72,10 +77,12 @@ WhisperX requires `transformers>=4.48`, so it conflicts with Chatterbox. When us
 | Speak (Qwen) | `mazinger speak` | no | `tts` + CUDA |
 | Speak (Chatterbox) | `mazinger speak --tts-engine chatterbox` | no | `tts-chatterbox` + CUDA |
 | Speak (MLX) | `mazinger speak --tts-engine mlx` | no | `tts-mlx` + Apple Silicon |
+| Speak (Pocket) | `mazinger speak --tts-engine pocket` | no | `tts-pocket` (CPU-only, English only) |
 | Subtitle embed | `mazinger subtitle` | yes | ffmpeg only |
 | Full dub (Qwen) | `mazinger dub` | no | `all-qwen` + CUDA |
 | Full dub (Chatterbox) | `mazinger dub --tts-engine chatterbox` | no | `all-chatterbox` + CUDA |
 | Full dub (MLX) | `mazinger dub --tts-engine mlx` | no | `all-mlx` + Apple Silicon |
+| Full dub (Pocket) | `mazinger dub --tts-engine pocket` | no | `tts-pocket` (CPU-only, English only) |
 
 ## System Dependencies
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -302,6 +302,29 @@ For transcription with MLX Whisper:
 mazinger transcribe audio.mp3 -o subs.srt --method mlx-whisper
 ```
 
+## Use Pocket TTS (CPU-only, no GPU needed)
+
+[Pocket TTS](https://github.com/kyutai-labs/pocket-tts) (Kyutai, 100M params) runs entirely
+on CPU. Install with `pip install "mazinger[tts-pocket]"`, then use `--tts-engine pocket`.
+Currently **English only**.
+
+```bash
+# With a predefined voice — no voice sample or HF account needed
+mazinger dub "https://youtube.com/watch?v=VIDEO_ID" \
+    --tts-engine pocket --pocket-voice alba \
+    --target-language English
+
+# With voice cloning from your own audio (requires accepting the gated model
+# terms at https://huggingface.co/kyutai/pocket-tts and `hf auth login`)
+mazinger speak --srt translated.srt --original-audio audio.mp3 \
+    --tts-engine pocket \
+    --voice-sample speaker.wav \
+    -o dubbed.wav
+```
+
+Predefined voices: `alba` · `marius` · `javert` · `jean` · `fantine` · `cosette` · `eponine` · `azelma`.
+Long voice references are automatically trimmed to 30 s to prevent hallucination.
+
 ## Control Playback Speed
 
 By default, dubbed segments are placed at their original timestamps without speed adjustment. Use tempo flags to control pacing:

--- a/mazinger/cli/_dub.py
+++ b/mazinger/cli/_dub.py
@@ -83,6 +83,7 @@ def handler(args: argparse.Namespace) -> None:
         chatterbox_model=args.chatterbox_model,
         chatterbox_exaggeration=args.chatterbox_exaggeration,
         chatterbox_cfg=args.chatterbox_cfg,
+        pocket_voice=getattr(args, "pocket_voice", None),
         cookies_from_browser=args.cookies_from_browser,
         cookies=args.cookies,
         quality=args.quality,

--- a/mazinger/cli/_groups.py
+++ b/mazinger/cli/_groups.py
@@ -184,7 +184,7 @@ def add_tts_engine(p: argparse.ArgumentParser) -> None:
     p.add_argument("--tts-language", default=None, type=_language_type,
                    help="Target TTS language (defaults to --target-language).")
     p.add_argument(
-        "--tts-engine", default="qwen", choices=["qwen", "chatterbox", "mlx"],
+        "--tts-engine", default="qwen", choices=["qwen", "chatterbox", "mlx", "pocket"],
         help="TTS engine: 'qwen' (Qwen3-TTS), 'chatterbox' (ResembleAI Chatterbox), or 'mlx' (Apple Silicon).",
     )
     p.add_argument("--mlx-tts-model", default=DEFAULT_MLX_MODEL,
@@ -193,6 +193,9 @@ def add_tts_engine(p: argparse.ArgumentParser) -> None:
                    help="Chatterbox exaggeration level (0.0-1.0, default 0.5).")
     p.add_argument("--chatterbox-cfg", type=float, default=0.5,
                    help="Chatterbox CFG weight (0.0-1.0, default 0.5).")
+    p.add_argument("--pocket-voice", default=None,
+                   help="Predefined Pocket TTS voice name (e.g. 'alba', 'marius'). "
+                        "Overrides --voice-sample when --tts-engine pocket.")
 
 
 def add_tempo(p: argparse.ArgumentParser) -> None:

--- a/mazinger/cli/_groups.py
+++ b/mazinger/cli/_groups.py
@@ -185,7 +185,8 @@ def add_tts_engine(p: argparse.ArgumentParser) -> None:
                    help="Target TTS language (defaults to --target-language).")
     p.add_argument(
         "--tts-engine", default="qwen", choices=["qwen", "chatterbox", "mlx", "pocket"],
-        help="TTS engine: 'qwen' (Qwen3-TTS), 'chatterbox' (ResembleAI Chatterbox), or 'mlx' (Apple Silicon).",
+        help="TTS engine: 'qwen' (Qwen3-TTS), 'chatterbox' (ResembleAI Chatterbox), "
+             "'mlx' (Apple Silicon), or 'pocket' (Pocket TTS, CPU-only, English only).",
     )
     p.add_argument("--mlx-tts-model", default=DEFAULT_MLX_MODEL,
                    help="MLX Qwen3-TTS model name (default: mlx-community/Qwen3-TTS-12Hz-0.6B-Base-bf16).")

--- a/mazinger/pipeline.py
+++ b/mazinger/pipeline.py
@@ -85,6 +85,7 @@ class MazingerDubber:
         chatterbox_model: str = "ResembleAI/chatterbox",
         chatterbox_exaggeration: float = 0.5,
         chatterbox_cfg: float = 0.5,
+        pocket_voice: str | None = None,
         loudness_match: bool = True,
         mix_background: bool = True,
         background_volume: float = 0.15,
@@ -462,8 +463,12 @@ class MazingerDubber:
             chatterbox_model=chatterbox_model,
             mlx_model=mlx_model,
         )
+        # Pocket TTS: allow predefined voice name to override ref audio
+        _ref_audio = voice_sample
+        if tts_engine == "pocket" and pocket_voice:
+            _ref_audio = pocket_voice
         voice_prompt = tts.create_voice_prompt(
-            tts_model, voice_sample, ref_text,
+            tts_model, _ref_audio, ref_text,
             engine=tts_engine,
             chatterbox_exaggeration=chatterbox_exaggeration,
             chatterbox_cfg=chatterbox_cfg,

--- a/mazinger/tts.py
+++ b/mazinger/tts.py
@@ -349,6 +349,10 @@ POCKET_VOICES = ("alba", "marius", "javert", "jean", "fantine", "cosette", "epon
 
 _POCKET_DEFAULT_VOICE = "alba"
 
+# Pocket TTS hallucinates (generates past max length without EOS) when the
+# reference audio is longer than ~30s.  Auto-trim anything beyond this.
+_POCKET_MAX_REF_SECONDS = 30
+
 
 def _load_pocket_model() -> Any:
     """Load a Pocket TTS model and return it.
@@ -403,23 +407,22 @@ def _create_pocket_voice_state(model: Any, ref_audio: str | None) -> Any:
 
         # 3. Zero-shot voice cloning — trim long references to avoid
         #    hallucination (Pocket TTS works best with ≤30s clips).
-        _MAX_REF_SECONDS = 30
         clone_path = ref_audio
         try:
             dur = sf.info(ref_audio).duration
-            if dur > _MAX_REF_SECONDS:
+            if dur > _POCKET_MAX_REF_SECONDS:
                 import subprocess
                 trimmed = os.path.splitext(ref_audio)[0] + "_pocket.wav"
                 if not os.path.isfile(trimmed):
                     subprocess.run(
                         ["ffmpeg", "-y", "-i", ref_audio,
-                         "-t", str(_MAX_REF_SECONDS), "-ar", "24000",
+                         "-t", str(_POCKET_MAX_REF_SECONDS), "-ar", "24000",
                          "-ac", "1", trimmed],
                         check=True, capture_output=True,
                     )
                 log.info(
                     "Trimmed reference audio from %.0fs to %ds for Pocket TTS",
-                    dur, _MAX_REF_SECONDS,
+                    dur, _POCKET_MAX_REF_SECONDS,
                 )
                 clone_path = trimmed
         except Exception:
@@ -460,6 +463,10 @@ class _PocketTTSWrapper(TTSWrapper):
         self.voice_state = voice_state
 
     def synthesize(self, text: str, language: str = "English") -> tuple[np.ndarray, int]:
+        if not text or not text.strip():
+            # Pocket TTS's tokenizer raises on empty input; return silence
+            # so the pipeline can continue and let assemble.py fill the gap.
+            return np.zeros(0, dtype=np.float32), self.model.sample_rate
         if language != "English":
             log.warning(
                 "Pocket TTS currently supports English only; "

--- a/mazinger/tts.py
+++ b/mazinger/tts.py
@@ -1,4 +1,4 @@
-"""Voice-cloned text-to-speech synthesis using Qwen3-TTS, Chatterbox, or MLX."""
+"""Voice-cloned text-to-speech synthesis using Qwen3-TTS, Chatterbox, MLX, or Pocket TTS."""
 
 from __future__ import annotations
 
@@ -31,7 +31,7 @@ def _remove_from_cache(obj: Any) -> None:
 #  TTS Engine Type
 # ═══════════════════════════════════════════════════════════════════════════════
 
-TTSEngine = Literal["qwen", "chatterbox", "mlx"]
+TTSEngine = Literal["qwen", "chatterbox", "mlx", "pocket"]
 DEFAULT_MLX_MODEL = "mlx-community/Qwen3-TTS-12Hz-0.6B-Base-bf16"
 
 SUPPORTED_LANGUAGES = (
@@ -342,6 +342,139 @@ class _MLXTTSWrapper(TTSWrapper):
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
+#  Pocket TTS Backend (CPU-only, lightweight)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+POCKET_VOICES = ("alba", "marius", "javert", "jean", "fantine", "cosette", "eponine", "azelma")
+
+_POCKET_DEFAULT_VOICE = "alba"
+
+
+def _load_pocket_model() -> Any:
+    """Load a Pocket TTS model and return it.
+
+    Pocket TTS is a lightweight 100M-parameter model that runs entirely
+    on CPU with no GPU required.  It supports zero-shot voice cloning
+    from a reference audio file (requires gated model access on HuggingFace)
+    or predefined voices.  Currently English only.
+    """
+    try:
+        from pocket_tts import TTSModel
+    except ImportError as e:
+        raise ImportError(
+            "pocket-tts not installed. Install with: pip install 'mazinger[tts-pocket]'\n"
+            "Or use --tts-engine qwen or --tts-engine chatterbox instead."
+        ) from e
+
+    model = TTSModel.load_model()
+    has_cloning = getattr(model, "has_voice_cloning", False)
+    log.info(
+        "Loaded Pocket TTS model (CPU, 100M params, voice_cloning=%s)",
+        has_cloning,
+    )
+    return model
+
+
+def _create_pocket_voice_state(model: Any, ref_audio: str | None) -> Any:
+    """Build a reusable voice state for Pocket TTS.
+
+    Tries the following in order:
+
+    1. If *ref_audio* matches a predefined voice name, use it directly.
+    2. If a pre-exported ``.safetensors`` file exists alongside the
+       reference audio, load it for faster initialisation.
+    3. If the model supports voice cloning, clone from *ref_audio*
+       (auto-trims references longer than 30s to prevent hallucination).
+    4. Otherwise fall back to the default predefined voice.
+    """
+    # 1. Check if ref_audio is a predefined voice name
+    if ref_audio and ref_audio in POCKET_VOICES:
+        log.info("Using predefined Pocket TTS voice: %s", ref_audio)
+        return model.get_state_for_audio_prompt(ref_audio)
+
+    has_cloning = getattr(model, "has_voice_cloning", False)
+
+    if ref_audio and has_cloning:
+        # 2. Check for pre-exported voice embedding
+        safetensors_path = os.path.splitext(ref_audio)[0] + ".safetensors"
+        if os.path.isfile(safetensors_path):
+            log.info("Loading exported Pocket TTS voice from %s", safetensors_path)
+            return model.get_state_for_audio_prompt(safetensors_path)
+
+        # 3. Zero-shot voice cloning — trim long references to avoid
+        #    hallucination (Pocket TTS works best with ≤30s clips).
+        _MAX_REF_SECONDS = 30
+        clone_path = ref_audio
+        try:
+            dur = sf.info(ref_audio).duration
+            if dur > _MAX_REF_SECONDS:
+                import subprocess
+                trimmed = os.path.splitext(ref_audio)[0] + "_pocket.wav"
+                if not os.path.isfile(trimmed):
+                    subprocess.run(
+                        ["ffmpeg", "-y", "-i", ref_audio,
+                         "-t", str(_MAX_REF_SECONDS), "-ar", "24000",
+                         "-ac", "1", trimmed],
+                        check=True, capture_output=True,
+                    )
+                log.info(
+                    "Trimmed reference audio from %.0fs to %ds for Pocket TTS",
+                    dur, _MAX_REF_SECONDS,
+                )
+                clone_path = trimmed
+        except Exception:
+            log.debug("Could not check/trim reference audio", exc_info=True)
+
+        voice_state = model.get_state_for_audio_prompt(clone_path)
+        log.info("Pocket TTS voice cloned from %s", clone_path)
+        return voice_state
+
+    # 4. Fall back to predefined voice
+    if ref_audio and not has_cloning:
+        log.warning(
+            "Pocket TTS voice cloning not available (accept terms at "
+            "https://huggingface.co/kyutai/pocket-tts and run 'hf auth login'). "
+            "Using predefined voice '%s' instead.",
+            _POCKET_DEFAULT_VOICE,
+        )
+    return model.get_state_for_audio_prompt(_POCKET_DEFAULT_VOICE)
+
+
+def _synthesize_pocket(
+    model: Any,
+    voice_state: Any,
+    text: str,
+) -> tuple[np.ndarray, int]:
+    """Generate audio using Pocket TTS. Returns (audio_array, sample_rate)."""
+    audio = model.generate_audio(voice_state, text)
+    audio_data = audio.squeeze().numpy()
+    return audio_data, model.sample_rate
+
+
+class _PocketTTSWrapper(TTSWrapper):
+
+    engine = "pocket"
+
+    def __init__(self, model: Any, voice_state: Any):
+        self.model = model
+        self.voice_state = voice_state
+
+    def synthesize(self, text: str, language: str = "English") -> tuple[np.ndarray, int]:
+        if language != "English":
+            log.warning(
+                "Pocket TTS currently supports English only; "
+                "received language=%r — output may be degraded", language,
+            )
+        return _synthesize_pocket(self.model, self.voice_state, text)
+
+    def unload(self) -> None:
+        _remove_from_cache(self.model)
+        del self.voice_state, self.model
+        gc.collect()
+        log.info("Pocket TTS model unloaded.")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
 #  Public API
 # ═══════════════════════════════════════════════════════════════════════════════
 
@@ -382,6 +515,8 @@ def load_model(
         model = _load_chatterbox_model(device, chatterbox_model)
     elif engine == "mlx":
         model = _load_mlx_model(mlx_model)
+    elif engine == "pocket":
+        model = _load_pocket_model()
     else:
         raise ValueError(f"Unknown TTS engine: {engine!r}")
 
@@ -424,6 +559,9 @@ def create_voice_prompt(
     elif engine == "mlx":
         log.info("MLX Qwen3-TTS voice clone configured from %s", ref_audio)
         return _MLXTTSWrapper(model, ref_audio, ref_text)
+    elif engine == "pocket":
+        voice_state = _create_pocket_voice_state(model, ref_audio)
+        return _PocketTTSWrapper(model, voice_state)
     else:
         raise ValueError(f"Unknown TTS engine: {engine!r}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,11 @@ tts-chatterbox = [
     "pandas>=2.2",  # Override chatterbox-tts pinned version for Python 3.12+
     # setuptools<70 removed: pkg_resources is deprecated but still present in setuptools 70+
 ]
+# TTS with Pocket TTS (lightweight, CPU-only, English only)
+# Compatible with ALL transcription backends (no GPU or transformers dependency).
+tts-pocket = [
+    "pocket-tts>=1.0",
+]
 # Optional: flash-attn for faster attention (requires CUDA, complex build)
 flash-attn = [
     "flash-attn>=2.0",


### PR DESCRIPTION
## Summary
- Adds **Pocket TTS** (Kyutai, 100M params, MIT license) as a third TTS engine alongside Qwen3-TTS and Chatterbox
- **CPU-only** — no GPU required, ~6x real-time on modern CPUs, no CUDA/torch version conflicts
- Supports **zero-shot voice cloning** from reference audio (requires [gated model access](https://huggingface.co/kyutai/pocket-tts))
- Includes **8 predefined voices**: `alba`, `marius`, `javert`, `jean`, `fantine`, `cosette`, `eponine`, `azelma`
- Gracefully falls back to predefined voice when cloning model is unavailable
- **English only** (warns on non-English language, doesn't crash)
- New optional dependency: `pip install "mazinger[tts-pocket]"`

## Changes
| File | Change |
|---|---|
| `tts.py` | New `_PocketTTSWrapper`, `_load_pocket_model`, `_create_pocket_voice_state`, `_synthesize_pocket`; updated `TTSEngine`, `load_model`, `create_voice_prompt` |
| `cli/_groups.py` | Added `"pocket"` to `--tts-engine` choices, new `--pocket-voice` arg |
| `cli/_dub.py` | Pass `pocket_voice` to pipeline |
| `pipeline.py` | `pocket_voice` param on `dub()`, override ref audio when set |
| `pyproject.toml` | New `tts-pocket` optional extra (`pocket-tts>=1.0`) |

## Usage
```bash
# With predefined voice (no special access needed)
mazinger dub video.mp4 --tts-engine pocket --pocket-voice alba

# With voice cloning (requires HF gated access)
mazinger dub video.mp4 --tts-engine pocket --voice-sample ./reference.wav

# CPU-only, no GPU needed
mazinger dub video.mp4 --tts-engine pocket --device cpu --pocket-voice marius
```

## Test plan
- [x] Verified model loads and predefined voice synthesis works (alba voice, 4.64s output)
- [x] Verified graceful fallback when voice cloning model is unavailable
- [x] Verified CLI parser accepts `--tts-engine pocket` and `--pocket-voice` across all subcommands
- [x] Verified `pipeline.py` passes `pocket_voice` through to `create_voice_prompt()`
- [ ] Test full `dub` pipeline end-to-end with Pocket TTS
- [ ] Test with voice cloning model (requires HF gated access)