### PR TITLE
fix: allow beam_size with mlx-whisper by logging info instead of error

### DIFF
--- a/mazinger/transcribe.py
+++ b/mazinger/transcribe.py
@@ -1185,11 +1185,9 @@ def transcribe(
         )
     elif method == "mlx-whisper":
         if beam_size is not None:
-            raise ValueError(
-                "beam_size not supported with mlx-whisper (uses sampling-based decoding). "
-                "Use method='faster-whisper' or method='whisperx' for beam search."
-            )
-        log.info("MLX Whisper uses sampling-based decoding")
+            log.info("MLX Whisper uses sampling-based decoding (beam_size is ignored)")
+        else:
+            log.info("MLX Whisper uses sampling-based decoding")
         raw_segments, detected_lang = _transcribe_mlx_whisper(
             audio_path,
             model=mlx_whisper_model,


### PR DESCRIPTION
## Description
Fixes #12 - beam_size not supported with mlx-whisper raises ValueError.

## Changes
- transcribe.py: Log info instead of raising error when beam_size is passed to mlx-whisper
- pipeline.py already handles passing beam_size=None for mlx-whisper method

## Testing
- Works with mlx-whisper method without errors

## Error Before
```
ValueError: beam_size not supported with mlx-whisper (uses sampling-based decoding). Use method='faster-whisper' or method='whisperx' for beam search.
```