### PR TITLE
docs: add Deepgram Nova 3 backend to README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 Mazinger chains ten stages into a single pipeline:
 
 1. **Download** — fetch a video from a URL or ingest a local file, extract the audio track
-2. **Transcribe** — convert speech to SRT subtitles (OpenAI Whisper API, faster-whisper, WhisperX, or MLX Whisper)
+2. **Transcribe** — convert speech to SRT subtitles (OpenAI Whisper API, faster-whisper, WhisperX, MLX Whisper, or Deepgram Nova 3)
 3. **Thumbnails** — use an LLM to pick key frames from the video for visual context
 4. **Describe** — analyze the transcript and thumbnails to produce a structured summary (title, key points, keywords)
 5. **Review** — optionally refine ASR output: fix typos, reshape punctuation, and convert technical terms to English
@@ -54,6 +54,9 @@ Add local transcription or TTS as optional extras:
 # Local transcription
 pip install "mazinger[transcribe-faster]"      # faster-whisper (default, recommended)
 pip install "mazinger[transcribe-whisperx]"    # WhisperX (optional, word-level alignment)
+
+# Cloud transcription (no GPU needed)
+pip install "mazinger[transcribe-deepgram]"    # Deepgram Nova 3 (cloud, free $200 credit)
 
 # Voice synthesis
 pip install "mazinger[tts]"                    # Qwen3-TTS (voice sample + transcript)
@@ -151,6 +154,26 @@ mazinger slice      "https://youtube.com/watch?v=VIDEO_ID" --start 00:01:00 --en
 mazinger transcribe ./output/projects/my-video/source/audio.mp3 -o subs.srt
 mazinger translate  --srt subs.srt --target-language French -o translated.srt
 mazinger subtitle   video.mp4 --srt translated.srt -o output.mp4
+```
+
+### Cloud transcription with Deepgram (no GPU required)
+
+Deepgram Nova 3 offers strong multilingual quality (including Arabic) and gives you **$200
+in free credits on sign-up with no credit card required** — enough to transcribe many hours
+of audio for free. Get your key at [deepgram.com](https://deepgram.com), then:
+
+```bash
+export DEEPGRAM_API_KEY=your_key_here
+
+# Standalone transcription
+mazinger transcribe "https://youtube.com/watch?v=VIDEO_ID" \
+    --method deepgram --language ar -o subs.srt
+
+# Full dubbing pipeline with Deepgram for STT
+mazinger dub "https://youtube.com/watch?v=VIDEO_ID" \
+    --transcribe-method deepgram \
+    --voice-theme narrator-m \
+    --target-language English
 ```
 
 ### Python API

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -37,10 +37,11 @@ mazinger dub <source> [options]
 | `--voice-theme` | — | Pre-defined voice theme (e.g. `narrator-m`, `warm-f`). See `mazinger profile list` |
 | `--voice-sample` | — | Path to reference voice audio file |
 | `--voice-script` | — | Path to transcript of the voice sample (or inline text) |
-| `--transcribe-method` | `faster-whisper` | `openai`, `faster-whisper`, `whisperx`, or `mlx-whisper` |
-| `--whisper-model` | varies by method | Whisper model name |
+| `--transcribe-method` | `faster-whisper` | `openai`, `faster-whisper`, `whisperx`, `mlx-whisper`, or `deepgram` |
+| `--whisper-model` | varies by method | Whisper/Deepgram model name |
 | `--mlx-whisper-model` | `mlx-community/whisper-large-v3-turbo` | MLX Whisper model name |
 | `--beam-size` | `5` | Beam size for decoding (faster-whisper/whisperx) |
+| `--deepgram-api-key` | `$DEEPGRAM_API_KEY` | Deepgram API key (required for `--transcribe-method deepgram`) |
 | `--device` | `auto` | `auto`, `cuda`, or `cpu` |
 | `--source-language` | `auto` | Source language for translation (or `auto` to detect) |
 | `--target-language` | `English` | Target language for translation |
@@ -185,8 +186,8 @@ If `source` is provided, the video is downloaded first and its audio is transcri
 |------|---------|-------------|
 | `--audio` | — | Path to audio file (overrides source) |
 | `-o`, `--output` | — | Output SRT path |
-| `--method` | `faster-whisper` | `openai`, `faster-whisper`, `whisperx`, or `mlx-whisper` |
-| `--model` | varies | Whisper model name (`whisper-1` for OpenAI, `large-v3` for local) |
+| `--method` | `faster-whisper` | `openai`, `faster-whisper`, `whisperx`, `mlx-whisper`, or `deepgram` |
+| `--model` | varies | Model name (`whisper-1` for OpenAI, `large-v3` for local, `nova-3` for Deepgram) |
 | `--device` | `auto` | `auto`, `cuda`, `cpu` |
 | `--batch-size` | `16` | Batch size for local transcription |
 | `--compute-type` | `float16` | Weight precision: `float16`, `int8`, `int8_float16` |
@@ -203,12 +204,17 @@ If `source` is provided, the video is downloaded first and its audio is transcri
 | `--llm-model` | `gpt-4.1` | LLM model for refinement |
 | `--llm-think` / `--no-llm-think` | — | Enable/disable LLM thinking mode |
 | `--openai-api-key` | `$OPENAI_API_KEY` | OpenAI API key (for cloud method) |
+| `--deepgram-api-key` | `$DEEPGRAM_API_KEY` | Deepgram API key (for `--method deepgram`) |
 
 **Examples:**
 
 ```bash
-# Cloud transcription
-mazinger transcribe --audio recording.mp3 -o subs.srt
+# Cloud transcription (OpenAI)
+mazinger transcribe --audio recording.mp3 -o subs.srt --method openai
+
+# Cloud transcription (Deepgram Nova 3 — free $200 credit, no card)
+mazinger transcribe --audio recording.mp3 -o subs.srt \
+    --method deepgram --language ar
 
 # Local with faster-whisper on GPU
 mazinger transcribe --audio recording.mp3 -o subs.srt \

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -40,7 +40,7 @@ mazinger dub <source> [options]
 | `--transcribe-method` | `faster-whisper` | `openai`, `faster-whisper`, `whisperx`, `mlx-whisper`, or `deepgram` |
 | `--whisper-model` | varies by method | Whisper/Deepgram model name |
 | `--mlx-whisper-model` | `mlx-community/whisper-large-v3-turbo` | MLX Whisper model name |
-| `--beam-size` | `5` | Beam size for decoding (faster-whisper/whisperx) |
+| `--beam-size` | — | Beam size for decoding (faster-whisper/whisperx) |
 | `--deepgram-api-key` | `$DEEPGRAM_API_KEY` | Deepgram API key (required for `--transcribe-method deepgram`) |
 | `--device` | `auto` | `auto`, `cuda`, or `cpu` |
 | `--source-language` | `auto` | Source language for translation (or `auto` to detect) |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -21,6 +21,15 @@ pip install "mazinger[transcribe-whisperx]"    # WhisperX — best word-level al
 
 Both require a CUDA GPU (or can fall back to CPU at reduced speed).
 
+### Cloud Transcription (no GPU required)
+
+```bash
+pip install "mazinger[transcribe-deepgram]"    # Deepgram Nova 3 — 47+ languages, free $200 credit
+```
+
+Deepgram offers strong multilingual quality (including Arabic) and gives new accounts $200
+in free credits without a credit card. Set `DEEPGRAM_API_KEY` and use `--method deepgram`.
+
 ### Voice Synthesis (TTS)
 
 ```bash
@@ -61,7 +70,8 @@ WhisperX requires `transformers>=4.48`, so it conflicts with Chatterbox. When us
 | Task | Command | Core install | Extra needed |
 |------|---------|:------------:|--------------|
 | Download | `mazinger download` | yes | — |
-| Transcribe (cloud) | `mazinger transcribe` | yes | — (OpenAI API) |
+| Transcribe (cloud, OpenAI) | `mazinger transcribe --method openai` | yes | — (OpenAI API) |
+| Transcribe (cloud, Deepgram) | `mazinger transcribe --method deepgram` | no | `transcribe-deepgram` + Deepgram API |
 | Transcribe (local) | `mazinger transcribe --method faster-whisper` | no | `transcribe-faster` + CUDA |
 | Transcribe (local) | `mazinger transcribe --method whisperx` | no | `transcribe-whisperx` + CUDA |
 | Transcribe (MLX) | `mazinger transcribe --method mlx-whisper` | no | `transcribe-mlx` + Apple Silicon |

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -155,7 +155,11 @@ mazinger dub "https://youtube.com/watch?v=VIDEO_ID" \
 
 ```bash
 # Cloud (OpenAI Whisper API)
-mazinger transcribe ./output/projects/my-video/source/audio.mp3 -o subs.srt
+mazinger transcribe ./output/projects/my-video/source/audio.mp3 -o subs.srt --method openai
+
+# Cloud (Deepgram Nova 3 — free $200 credit, no card required)
+export DEEPGRAM_API_KEY=your_key
+mazinger transcribe audio.mp3 -o subs.srt --method deepgram --language ar
 
 # Local with faster-whisper (default)
 mazinger transcribe audio.mp3 -o subs.srt --method faster-whisper --device cuda


### PR DESCRIPTION
## Summary

The Deepgram STT backend was merged in #3 but the documentation wasn't updated, so new users had no way to discover it from the README or `docs/`. This PR fixes that.

## Changes

### `README.md`
- **Feature list** (line 23): Added Deepgram Nova 3 to the transcription backends list
- **Installation** (line 55): Added `pip install "mazinger[transcribe-deepgram]"` under a new "Cloud transcription (no GPU needed)" heading
- **New Quick Start section**: \"Cloud transcription with Deepgram (no GPU required)\" highlighting:
  - Strong multilingual quality including Arabic
  - **$200 free credits on sign-up, no credit card required**
  - Standalone and full-pipeline examples

### `docs/cli-reference.md`
- Updated `--transcribe-method` and `--method` choice lists to include `deepgram` (both `dub` and `transcribe` subcommand tables)
- Added `--deepgram-api-key` flag entry to both tables
- Added a Deepgram transcription example alongside the existing OpenAI and local examples

### `docs/installation.md`
- New \"Cloud Transcription (no GPU required)\" section with `transcribe-deepgram` install
- Added Deepgram row to the \"What Each Task Requires\" matrix
- Clarified OpenAI row label (was just \"Cloud\", now \"Cloud, OpenAI\")

### `docs/quick-start.md`
- Added a Deepgram transcription example in the Stages section

## Motivation

Deepgram is a compelling option for users who:
- Don't want to configure a local CUDA environment
- Need quality multilingual transcription (especially Arabic)
- Don't want to pay per-minute for an OpenAI API key
- Want to try the pipeline without any upfront cost (free $200 credit)

Without documentation, none of these users would know this option exists today. This PR makes it discoverable.

## Test plan

- [x] README renders correctly (markdown preview)
- [x] CLI reference examples match the actual `--help` output
- [x] Install commands match the extras defined in `pyproject.toml`
- [x] All links and backticks close correctly