### PR TITLE
feat: Add support for custom HuggingFace profile datasets

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,7 +23,7 @@ mazinger dub "https://youtube.com/watch?v=VIDEO_ID" --clone-profile abubakr
 # Or pass directly
 mazinger dub "https://youtube.com/watch?v=VIDEO_ID" \
     --clone-profile abubakr \
-    --openai-api-key "sk..."
+    --openai-api-key "sk-..."
 ```
 
 ## Using a Custom LLM Provider

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,18 +7,23 @@
 | `OPENAI_API_KEY` | — | OpenAI API key for transcription and LLM tasks |
 | `OPENAI_BASE_URL` | — | Custom base URL for OpenAI-compatible API providers |
 | `OPENAI_MODEL` | `gpt-4.1` | Default LLM model for translation, description, etc. |
+| `HF_TOKEN` | — | HuggingFace token for accessing private voice profile datasets |
+| `MAZINGER_PROFILES_REPO_URL` | — | Custom HuggingFace dataset URL for voice profiles |
 
 CLI flags take precedence over environment variables. If neither is set, `OPENAI_MODEL` defaults to `gpt-4.1`.
 
 ```bash
 # Set via environment
 export OPENAI_API_KEY="sk-..."
+export HF_TOKEN="hf_..."           # For private datasets
+export MAZINGER_PROFILES_REPO_URL="https://huggingface.co/datasets/YOUR_NAME/dataset/resolve/main/profiles"
+
 mazinger dub "https://youtube.com/watch?v=VIDEO_ID" --clone-profile abubakr
 
 # Or pass directly
 mazinger dub "https://youtube.com/watch?v=VIDEO_ID" \
     --clone-profile abubakr \
-    --openai-api-key "sk-..."
+    --openai-api-key "sk..."
 ```
 
 ## Using a Custom LLM Provider

--- a/docs/voice-profiles.md
+++ b/docs/voice-profiles.md
@@ -458,12 +458,12 @@ When you set `MAZINGER_PROFILES_REPO_URL`:
 ### Python API
 
 ```python
-from mazinger.profiles import fetch_profile
 import os
 
 os.environ["HF_TOKEN"] = "hf_..."
 os.environ["MAZINGER_PROFILES_REPO_URL"] = "https://huggingface.co/datasets/..."
 
+from mazinger.profiles import fetch_profile
 voice, script = fetch_profile("your-voice-name")
 ```
 

--- a/docs/voice-profiles.md
+++ b/docs/voice-profiles.md
@@ -393,6 +393,81 @@ mazinger dub "https://youtube.com/watch?v=VIDEO_ID" --clone-profile my-name
 
 ---
 
+## Using a Private HuggingFace Dataset
+
+You can use your own private HuggingFace dataset instead of the default public one. This is useful for storing custom voice profiles securely.
+
+### Setup
+
+**1. Set environment variables:**
+
+```bash
+# Your HuggingFace write token (from https://huggingface.co/settings/tokens)
+export HF_TOKEN="hf_..."
+
+# Your private dataset URL
+export MAZINGER_PROFILES_REPO_URL="https://huggingface.co/datasets/YOUR_USERNAME/your-dataset/resolve/main/profiles"
+```
+
+Add these to your shell profile (`~/.zshrc`) for persistence.
+
+**2. Get your token:**
+
+```bash
+pip install huggingface_hub
+hf auth login  # or go to https://huggingface.co/settings/tokens
+```
+
+### Upload a Profile
+
+**1. Prepare the folder structure:**
+
+```bash
+mkdir -p profiles/your-voice-name
+cp your-voice.wav profiles/your-voice-name/voice.wav
+cp your-transcript.txt profiles/your-voice-name/script.txt
+```
+
+**2. Upload to your private dataset:**
+
+```bash
+# Create dataset first if needed: https://huggingface.co/datasets/new
+
+hf upload YOUR_USERNAME/mazinger-dubber-profiles \
+    ./profiles/your-voice-name \
+    --repo-type dataset
+```
+
+### Use Your Private Profile
+
+```bash
+mazinger dub "https://youtube.com/watch?v=VIDEO_ID" \
+    --clone-profile your-voice-name \
+    --target-language Spanish
+```
+
+### Priority Order
+
+When you set `MAZINGER_PROFILES_REPO_URL`:
+
+1. Custom repo is checked first
+2. If profile exists in both custom and default → prompts you to select (CLI) or raises error (API)
+3. Falls back to default repo if not found in custom
+
+### Python API
+
+```python
+from mazinger.profiles import fetch_profile
+import os
+
+os.environ["HF_TOKEN"] = "hf_..."
+os.environ["MAZINGER_PROFILES_REPO_URL"] = "https://huggingface.co/datasets/..."
+
+voice, script = fetch_profile("your-voice-name")
+```
+
+---
+
 ## Python API for Themes and Profiles
 
 ### List available themes

--- a/docs/voice-profiles.md
+++ b/docs/voice-profiles.md
@@ -402,7 +402,7 @@ You can use your own private HuggingFace dataset instead of the default public o
 **1. Set environment variables:**
 
 ```bash
-# Your HuggingFace write token (from https://huggingface.co/settings/tokens)
+# Your HuggingFace token (from https://huggingface.co/settings/tokens)
 export HF_TOKEN="hf_..."
 
 # Your private dataset URL
@@ -435,6 +435,7 @@ cp your-transcript.txt profiles/your-voice-name/script.txt
 
 hf upload YOUR_USERNAME/mazinger-dubber-profiles \
     ./profiles/your-voice-name \
+    profiles/your-voice-name \
     --repo-type dataset
 ```
 
@@ -451,7 +452,7 @@ mazinger dub "https://youtube.com/watch?v=VIDEO_ID" \
 When you set `MAZINGER_PROFILES_REPO_URL`:
 
 1. Custom repo is checked first
-2. If profile exists in both custom and default → prompts you to select (CLI) or raises error (API)
+2. If profile exists in both custom and default → uses custom repo
 3. Falls back to default repo if not found in custom
 
 ### Python API

--- a/mazinger/profiles.py
+++ b/mazinger/profiles.py
@@ -5,15 +5,17 @@ from __future__ import annotations
 import logging
 import os
 import subprocess
+import sys
 import tempfile
 import urllib.request
 from urllib.error import HTTPError
 
 log = logging.getLogger(__name__)
 
-PROFILES_REPO_URL = (
-    "https://huggingface.co/datasets/bakrianoo/mazinger-dubber-profiles/resolve/main/profiles"
-)
+CUSTOM_PROFILES_REPO_URL = os.environ.get("MAZINGER_PROFILES_REPO_URL")
+DEFAULT_PROFILES_REPO_URL = "https://huggingface.co/datasets/bakrianoo/mazinger-dubber-profiles/resolve/main/profiles"
+PROFILES_REPO_URL = DEFAULT_PROFILES_REPO_URL
+HF_TOKEN = os.environ.get("HF_TOKEN")
 
 SCRIPT_FILENAME = "script.txt"
 VOICE_EXTENSIONS = ("wav", "m4a", "mp3")
@@ -23,11 +25,19 @@ MAX_CLONE_DURATION = 60.0
 MIN_CLONE_WORDS = 20
 
 
+def _make_request(url: str, method: str = "GET") -> urllib.request.Request:
+    req = urllib.request.Request(url, method=method)
+    if HF_TOKEN:
+        req.add_header("Authorization", f"Bearer {HF_TOKEN}")
+    return req
+
+
 def _download_file(url: str, dest: str) -> None:
-    """Download *url* to *dest*, creating parent directories as needed."""
     os.makedirs(os.path.dirname(dest), exist_ok=True)
     log.info("Downloading %s -> %s", url, dest)
-    urllib.request.urlretrieve(url, dest)  # noqa: S310 – trusted HF URL
+    with urllib.request.urlopen(_make_request(url), timeout=30) as response:
+        with open(dest, "wb") as f:
+            f.write(response.read())
 
 
 def _convert_to_wav(src: str, dest: str) -> None:
@@ -664,13 +674,46 @@ def fetch_profile(profile_name: str, cache_dir: str | None = None) -> tuple[str,
     if os.path.isdir(profile_name):
         return _load_local_profile(profile_name)
 
+    def _profile_exists(base_url: str) -> bool:
+        url = f"{base_url}/{profile_name}/{SCRIPT_FILENAME}"
+        try:
+            urllib.request.urlopen(_make_request(url, "HEAD"), timeout=10)
+            return True
+        except Exception:
+            return False
+
+    default_url = DEFAULT_PROFILES_REPO_URL
+    custom_url = CUSTOM_PROFILES_REPO_URL
+
+    in_default = _profile_exists(default_url)
+    in_custom = _profile_exists(custom_url) if custom_url else False
+
+    if in_default and in_custom:
+        if sys.stdin.isatty():
+            print(f"Profile '{profile_name}' found in both repos:")
+            print(f"  [1] Default: {default_url}")
+            print(f"  [2] Custom: {custom_url}")
+            choice = input("Select repo (1/2): ").strip()
+            base_url = custom_url if choice == "2" else default_url
+        else:
+            raise ValueError(
+                f"Profile '{profile_name}' exists in both default and custom repos. "
+                f"Run interactively to select, or unset MAZINGER_PROFILES_REPO_URL."
+            )
+    elif in_custom:
+        base_url = custom_url
+    elif in_default:
+        base_url = default_url
+    else:
+        raise FileNotFoundError(f"Profile '{profile_name}' not found")
+
     if cache_dir is None:
         cache_dir = os.path.join(
             tempfile.gettempdir(), "mazinger-dubber-profiles"
         )
 
     profile_dir = os.path.join(cache_dir, profile_name)
-    base = f"{PROFILES_REPO_URL}/{profile_name}"
+    base = f"{base_url}/{profile_name}"
 
     # Download script
     script_path = os.path.join(profile_dir, SCRIPT_FILENAME)

--- a/mazinger/profiles.py
+++ b/mazinger/profiles.py
@@ -689,15 +689,8 @@ def fetch_profile(profile_name: str, cache_dir: str | None = None) -> tuple[str,
     in_custom = _profile_exists(custom_url) if custom_url else False
 
     if in_default and in_custom:
-        if sys.stdin.isatty():
-            print(f"Profile '{profile_name}' found in both repos:")
-            print(f"  [1] Default: {default_url}")
-            print(f"  [2] Custom: {custom_url}")
-            choice = input("Select repo (1/2): ").strip()
-            base_url = custom_url if choice == "2" else default_url
-        else:
-            base_url = custom_url
-            log.info("Profile found in both repos, using custom repo")
+        base_url = custom_url
+        log.info("Profile found in both repos, using custom repo")
     elif in_custom:
         base_url = custom_url
     elif in_default:

--- a/mazinger/profiles.py
+++ b/mazinger/profiles.py
@@ -678,7 +678,8 @@ def fetch_profile(profile_name: str, cache_dir: str | None = None) -> tuple[str,
     def _profile_exists(base_url: str) -> tuple[bool, str]:
         url = f"{base_url}/{profile_name}/{SCRIPT_FILENAME}"
         try:
-            urllib.request.urlopen(_make_request(url, "HEAD"), timeout=10)
+            with urllib.request.urlopen(_make_request(url, "HEAD"), timeout=10) as response:
+                pass
             return True, ""
         except HTTPError as e:
             return False, str(e.code)

--- a/mazinger/profiles.py
+++ b/mazinger/profiles.py
@@ -691,26 +691,36 @@ def fetch_profile(profile_name: str, cache_dir: str | None = None) -> tuple[str,
     default_url = DEFAULT_PROFILES_REPO_URL
     custom_url = CUSTOM_PROFILES_REPO_URL
 
-    in_default, default_err = _profile_exists(default_url)
-    in_custom, custom_err = _profile_exists(custom_url) if custom_url else (False, "")
+    default_err = ""
+    custom_err = ""
 
-    if in_default and in_custom:
-        base_url = custom_url
-        log.info("Profile found in both repos, using custom repo")
-    elif in_custom:
-        base_url = custom_url
-    elif in_default:
-        base_url = default_url
+    if custom_url:
+        in_custom, custom_err = _profile_exists(custom_url)
+        if in_custom:
+            base_url = custom_url
+        else:
+            in_default, default_err = _profile_exists(default_url)
+            if in_default:
+                base_url = default_url
+            else:
+                msg = f"Profile '{profile_name}' not found in any repo."
+                if custom_err:
+                    if "401" in custom_err:
+                        msg += " Custom repo requires auth - set HF_TOKEN."
+                    elif "404" in custom_err:
+                        msg += " Custom repo: check name and that files are named 'script.txt' and 'voice.wav'."
+                if default_err:
+                    msg += f" Default repo error: {default_err}"
+                raise FileNotFoundError(msg)
     else:
-        msg = f"Profile '{profile_name}' not found in any repo."
-        if custom_url and custom_err:
-            if "401" in custom_err:
-                msg += " Custom repo requires auth - set HF_TOKEN."
-            elif "404" in custom_err:
-                msg += " Custom repo: check name and that files are named 'script.txt' and 'voice.wav'."
-        if not in_default and default_err:
-            msg += f" Default repo error: {default_err}"
-        raise FileNotFoundError(msg)
+        in_default, default_err = _profile_exists(default_url)
+        if in_default:
+            base_url = default_url
+        else:
+            msg = f"Profile '{profile_name}' not found in any repo."
+            if default_err:
+                msg += f" Default repo error: {default_err}"
+            raise FileNotFoundError(msg)
 
     if cache_dir is None:
         cache_dir = os.path.join(

--- a/mazinger/profiles.py
+++ b/mazinger/profiles.py
@@ -696,10 +696,8 @@ def fetch_profile(profile_name: str, cache_dir: str | None = None) -> tuple[str,
             choice = input("Select repo (1/2): ").strip()
             base_url = custom_url if choice == "2" else default_url
         else:
-            raise ValueError(
-                f"Profile '{profile_name}' exists in both default and custom repos. "
-                f"Run interactively to select, or unset MAZINGER_PROFILES_REPO_URL."
-            )
+            base_url = custom_url
+            log.info("Profile found in both repos, using custom repo")
     elif in_custom:
         base_url = custom_url
     elif in_default:

--- a/mazinger/profiles.py
+++ b/mazinger/profiles.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import logging
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
 import urllib.request
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 
 log = logging.getLogger(__name__)
 
@@ -37,7 +38,7 @@ def _download_file(url: str, dest: str) -> None:
     log.info("Downloading %s -> %s", url, dest)
     with urllib.request.urlopen(_make_request(url), timeout=30) as response:
         with open(dest, "wb") as f:
-            f.write(response.read())
+            shutil.copyfileobj(response, f)
 
 
 def _convert_to_wav(src: str, dest: str) -> None:
@@ -674,19 +675,23 @@ def fetch_profile(profile_name: str, cache_dir: str | None = None) -> tuple[str,
     if os.path.isdir(profile_name):
         return _load_local_profile(profile_name)
 
-    def _profile_exists(base_url: str) -> bool:
+    def _profile_exists(base_url: str) -> tuple[bool, str]:
         url = f"{base_url}/{profile_name}/{SCRIPT_FILENAME}"
         try:
             urllib.request.urlopen(_make_request(url, "HEAD"), timeout=10)
-            return True
-        except Exception:
-            return False
+            return True, ""
+        except HTTPError as e:
+            return False, str(e.code)
+        except URLError as e:
+            return False, str(e.reason)
+        except Exception as e:
+            return False, str(e)
 
     default_url = DEFAULT_PROFILES_REPO_URL
     custom_url = CUSTOM_PROFILES_REPO_URL
 
-    in_default = _profile_exists(default_url)
-    in_custom = _profile_exists(custom_url) if custom_url else False
+    in_default, default_err = _profile_exists(default_url)
+    in_custom, custom_err = _profile_exists(custom_url) if custom_url else (False, "")
 
     if in_default and in_custom:
         base_url = custom_url
@@ -696,7 +701,15 @@ def fetch_profile(profile_name: str, cache_dir: str | None = None) -> tuple[str,
     elif in_default:
         base_url = default_url
     else:
-        raise FileNotFoundError(f"Profile '{profile_name}' not found")
+        msg = f"Profile '{profile_name}' not found in any repo."
+        if custom_url and custom_err:
+            if "401" in custom_err:
+                msg += " Custom repo requires auth - set HF_TOKEN."
+            elif "404" in custom_err:
+                msg += " Custom repo: check name and that files are named 'script.txt' and 'voice.wav'."
+        if not in_default and default_err:
+            msg += f" Default repo error: {default_err}"
+        raise FileNotFoundError(msg)
 
     if cache_dir is None:
         cache_dir = os.path.join(


### PR DESCRIPTION
## Summary

This feature allows users to configure a custom HuggingFace dataset URL for voice profiles instead of using the default  dataset.

## Motivation

Users may want to:
- Use their own private voice profiles
- Share custom voice profiles without contributing to the main dataset
- Test different profile collections without modifying the default

## Implementation

### Environment Variables

-  - Custom HuggingFace dataset URL
-  - HuggingFace token for private datasets

### Resolution Logic

1. Check custom repo if set
2. Fall back to default repo
3. If profile exists in both → uses custom repo

### Files Changed

- : Add custom repo support with fallback logic

Closes #16