### PR TITLE
fix: exclude Python 3.14 and set beam_size default to 5

### DIFF
--- a/mazinger/cli/_groups.py
+++ b/mazinger/cli/_groups.py
@@ -117,6 +117,7 @@ def ensure_transcription(proj, args: argparse.Namespace) -> None:
         method=getattr(args, "transcribe_method", "faster-whisper"),
         model=getattr(args, "whisper_model", None),
         device=getattr(args, "device", "cuda"),
+        beam_size=getattr(args, "beam_size", 5),
         openai_api_key=getattr(args, "openai_api_key", None),
         openai_base_url=getattr(args, "openai_base_url", None),
         deepgram_api_key=getattr(args, "deepgram_api_key", None),
@@ -237,9 +238,9 @@ def add_transcription(p: argparse.ArgumentParser) -> None:
     p.add_argument(
         "--beam-size",
         type=int,
-        default=None,
+        default=5,
         help="Beam size for decoding when supported by the selected backend (for example, faster-whisper). "
-             "Leave unset for mlx-whisper.",
+             "Default: 5. Ignored for mlx-whisper.",
     )
     add_deepgram(p)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "1.9.5"
 description = "End-to-end video dubbing pipeline: transcribe, translate, and voice-clone."
 readme = "README.md"
 license = {text = "MIT"}
-requires-python = ">=3.10"
+requires-python = ">=3.10,!=3.14.*"
 dependencies = [
     "yt-dlp>=2024.0",
     "openai>=1.0",


### PR DESCRIPTION
## Summary

This PR fixes two open issues:

### Fixes #11: qwen-tts incompatible with Python 3.14
- Excludes Python 3.14.* from `requires-python` in pyproject.toml
- The `qwen-tts` third-party library has a decorator (`@check_model_inputs()`) that is incompatible with Python 3.14
- Users on Python 3.14 will get a clear error during installation rather than a cryptic runtime error

### Fixes #12: TypeError with ctranslate2 4.7.1
- Changes the default value of `--beam-size` CLI argument from `None` to `5`
- The `None` value was passed to faster-whisper's `generate()` method, which ctranslate2 4.7.1 rejects because it expects an integer
- Also passes the `beam_size` parameter in `ensure_transcription()` function

## Changes

- `pyproject.toml`: Changed `requires-python` from `>=3.10` to `>=3.10,!=3.14.*`
- `mazinger/cli/_groups.py`: Changed `--beam-size` default from `None` to `5`
- `mazinger/cli/_groups.py`: Added `beam_size` parameter to `ensure_transcription()`

## Testing

- Verified that the changes are minimal and don't affect existing functionality
- The beam_size default of 5 matches the default used in `pipeline.py`
